### PR TITLE
switch to caf ril from custom ril

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -151,7 +151,9 @@ EXTENDED_FONT_FOOTPRINT := true
 TARGET_POWERHAL_VARIANT := qcom
 
 # RIL
-BOARD_RIL_CLASS := ../../../$(DEVICE_PATH)/ril/
+TARGET_RIL_VARIANT := caf
+PROTOBUF_SUPPORTED := true
+
 
 # SELinux
 include device/qcom/sepolicy/sepolicy.mk


### PR DESCRIPTION
cm already gave us caf ril to use . specially mediatek device use custom ril
